### PR TITLE
Temporarily remove date-range flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,7 +155,7 @@ dependencies = [
 
 [[package]]
 name = "log-cli"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "log-cli"
-version = "0.0.1"
+version = "0.0.2"
 edition = "2021"
 authors = ["cnpryer <cnpryer@gmail.com>"]
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -84,8 +84,6 @@ ARGS:
                   entire file will be displayed.
 
 OPTIONS:
- (TODO) --date-range <VALUE>...    Date range to display. Must be a valid date range format
-                                   (ex:"2022-01-01" "2022-01-02").
     -h, --help                     Print help information
         --head <VALUE>             Display the top VALUE lines.
         --keywords <VALUE>...      Keywords to search for in the log file. Multiple keywords can be

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,93 @@
+//! log-cli: <small>Command line interface for log files.</small>
+//!
+//! ## Installation
+//!
+//! To install `log-cli` run:
+//!
+//! ```console
+//! cargo install log-cli
+//! ```
+//!
+//! ## Usage
+//!
+//! ```console
+//! > log-cli sample.log
+//!
+//! ln00 2022-01-01 07:00:00,0 [info] module1  Message Subject: Text for a message.
+//! ln01 2022-01-01 08:00:00,0 [info] module1  Message Subject: Text for a message.
+//! ln02 2022-01-01 09:00:00,0 [debug] module2  Message Subject: Text for a message.
+//! ln03 2022-01-01 10:00:00,0 [debug] module2  Message Subject: Text for a message.
+//! ln04 2022-01-01 11:00:00,0 [debug] module2  Message Subject: Text for a message.
+//! ln05 2022-01-01 12:00:00,0 [info] module3  Message Subject: Text for a message.
+//! ln06 2022-01-01 13:00:00,0 [info] module3  Message Subject: Text for a message.
+//! ln07 2022-01-01 14:00:00,0 [info] module1  Message Subject: Text for a message.
+//! ln08 2022-01-01 15:00:00,0 [info] module1  Message Subject: Text for a message.
+//! ln09 2022-01-01 16:00:00,0 [info] module1  Message Subject: Text for a message.
+//! ln10 2022-01-01 17:00:00,0 [info] module1  Message Subject: Text for a message.
+//! ln11 2022-01-01 18:00:00,0 [info] module1  Message Subject: Text for a message.
+//! ln12 2022-01-01 19:00:00,0 [info] module1  Message Subject: Text for a message.
+//! ln13 2022-01-01 20:00:00,0 [debug] module5  Message Subject: Text for a message.
+//! ln14 2022-01-01 21:00:00,0 [info] module2  Message Subject: Text for a message.
+//! ln15 2022-01-01 22:00:00,0 [info] module2  Message Subject: Text for a message.
+//! ln16 2022-01-01 23:00:00,0 [info] module6  Message Subject: Text for a message.
+//! ln17 2022-01-02 00:00:00,0 [warning] module1  Message Subject: Text for a message.
+//! ln18 2022-01-02 01:00:00,0 [info] module10  Message Subject: Text for a message.
+//! ln19 2022-01-02 02:00:00,0 [info] module1  Message Subject: Text for a message.
+//! ln20 2022-01-02 03:00:00,0 [debug] module12  Message Subject: Text for a message.
+//! ln21 2022-01-02 04:00:00,0 [warning] module11  Message Subject: Text for a message.
+//! ln22 2022-01-02 05:00:00,0 [info] module7  Message Subject: Text for a message.
+//! ln23 2022-01-02 06:00:00,0 [info] module6  Message Subject: Text for a message.
+//! ```
+//!
+//! ### View using keywords
+//!
+//! ```console
+//! > log-cli sample.log --keywords "[debug]" "[warning]"
+//!
+//! ln02 2022-01-01 09:00:00,0 [debug] module2  Message Subject: Text for a message.
+//! ln03 2022-01-01 10:00:00,0 [debug] module2  Message Subject: Text for a message.
+//! ln04 2022-01-01 11:00:00,0 [debug] module2  Message Subject: Text for a message.
+//! ln13 2022-01-01 20:00:00,0 [debug] module5  Message Subject: Text for a message.
+//! ln17 2022-01-02 00:00:00,0 [warning] module1  Message Subject: Text for a message.
+//! ln20 2022-01-02 03:00:00,0 [debug] module12  Message Subject: Text for a message.
+//! ln21 2022-01-02 04:00:00,0 [warning] module11  Message Subject: Text for a message.
+//! ```
+//!
+//! ### View using a line range
+//!
+//! ```console
+//! > log-cli sample.log --line-range 20 30
+//!
+//! ln20 2022-01-02 03:00:00,0 [debug] module12  Message Subject: Text for a message.
+//! ln21 2022-01-02 04:00:00,0 [warning] module11  Message Subject: Text for a message.
+//! ln22 2022-01-02 05:00:00,0 [info] module7  Message Subject: Text for a message.
+//! ln23 2022-01-02 06:00:00,0 [info] module6  Message Subject: Text for a message.
+//! ```
+//!
+//! ### More usage
+//!
+//! ```console
+//! > log-cli --help
+//!
+//! Command line interface for log files.
+//!
+//! USAGE:
+//!     log-cli [OPTIONS] [--] [LOG_FILE]
+//!
+//! ARGS:
+//!     <LOG_FILE>    Path to log file to be read. By default if no additional flags are passed the
+//!                   entire file will be displayed.
+//!
+//! OPTIONS:
+//!     -h, --help                     Print help information
+//!         --head <VALUE>             Display the top VALUE lines.
+//!         --keywords <VALUE>...      Keywords to search for in the log file. Multiple keywords can be
+//!                                    passed (ex: these are all keywords).
+//!         --line-range <VALUE>...    Line number range to display. Must be a valid integer range
+//!                                    format (ex: 0 10 to display the first 10 lines).
+//!     -V, --version                  Print version information
+//! ```
+
 /// `File` reading logic for log files.
 pub mod read;
 /// Validation logic for argument values and more.

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use clap::{arg, value_parser, App, Command, ErrorKind};
 use log_cli::{read::read_file, validate, view::Viewer};
 
-const VERSION: &str = "0.0.1";
+const VERSION: &str = "0.0.2";
 
 fn main() {
     // Create main clap command.
@@ -14,7 +14,8 @@ fn main() {
     // Get optional argument values.
     let keywords = matches.get_many::<String>("keywords");
     let line_range = matches.get_many::<usize>("line-range");
-    let date_range = matches.get_many::<String>("date-range");
+    // TODO
+    let date_range = None; //matches.get_many::<String>("date-range");
     let head = matches.get_one::<usize>("head");
 
     // Certain arguments cannot be used together. Error if this is the case.
@@ -79,15 +80,15 @@ fn cli() -> App<'static> {
                 .max_values(2)
                 .help("Line number range to display. Must be a valid integer range format (ex: 0 10 to display the first 10 lines)."),
         )
+        // .arg(
+        //     arg!(--"date-range" <VALUE>)
+        //         .required(false)
+        //         .value_parser(validate::valid_date_range_value)
+        //         .multiple_values(true)
+        //         .min_values(1)
+        //         .max_values(2)
+        //         .help("Date range to display. Must be a valid date range format (ex:\"2022-01-01\" \"2022-01-02\")."),
         .arg(
-            arg!(--"date-range" <VALUE>)
-                .required(false)
-                .value_parser(validate::valid_date_range_value)
-                .multiple_values(true)
-                .min_values(1)
-                .max_values(2)
-                .help("Date range to display. Must be a valid date range format (ex:\"2022-01-01\" \"2022-01-02\")."),
-        ).arg(
             arg!(--head <VALUE>).default_missing_value("5")
             .required(false).value_parser(value_parser!(usize))
             .help("Display the top VALUE lines.")


### PR DESCRIPTION
Instead of exposing an unimplemented/wip flag, disable as an argument for now and set to None
